### PR TITLE
No need of mach/platform.h

### DIFF
--- a/rpi-cobalt-kmod/rpi-cobalt.c
+++ b/rpi-cobalt-kmod/rpi-cobalt.c
@@ -19,7 +19,6 @@
 #include <linux/kernel.h>
 #include <linux/init.h>
 #include <linux/platform_device.h>
-#include <mach/platform.h>
 #include <linux/gpio.h>
 #include <linux/leds.h>
 #include <linux/io.h>


### PR DESCRIPTION
<mach/platform.h> is not found and therefore fails compilation.